### PR TITLE
[V2] Add POB support to v2 client

### DIFF
--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -66,6 +66,8 @@ import com.ning.billing.recurly.model.InvoiceTemplates;
 import com.ning.billing.recurly.model.Invoices;
 import com.ning.billing.recurly.model.Item;
 import com.ning.billing.recurly.model.Items;
+import com.ning.billing.recurly.model.PerformanceObligation;
+import com.ning.billing.recurly.model.PerformanceObligations;
 import com.ning.billing.recurly.model.Plan;
 import com.ning.billing.recurly.model.Plans;
 import com.ning.billing.recurly.model.Purchase;
@@ -2613,6 +2615,29 @@ public class RecurlyClient {
      */
     public GeneralLedgerAccount getGeneralLedgerAccount(final String generalLedgerAccountUUID) {
         return doGET(GeneralLedgerAccounts.GENERAL_LEDGER_ACCOUNTS_RESOURCE + "/" + urlEncode(generalLedgerAccountUUID), GeneralLedgerAccount.class);
+    }
+
+    /**
+     * Get a specific PerformanceObligation
+     * <p>
+     * Returns the requested performance obligation
+     *
+     * @param performanceObligationUUID performance obligation uuid
+     * @return The requested performance obligation
+     */
+    public PerformanceObligation getPerformanceObligation(final String performanceObligationUUID) {
+        return doGET(PerformanceObligations.PERFORMANCE_OBLIGATIONS_RESOURCE + "/" + urlEncode(performanceObligationUUID), PerformanceObligation.class);
+    }
+
+    /**
+     * Fetch PerformanceObligations
+     * <p>
+     * Returns information about all performance obligations.
+     *
+     * @return performance obligation object on success, null otherwise
+     */
+    public PerformanceObligations getPerformanceObligations() {
+        return doGET(PerformanceObligations.PERFORMANCE_OBLIGATIONS_RESOURCE, PerformanceObligations.class);
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/model/PerformanceObligation.java
+++ b/src/main/java/com/ning/billing/recurly/model/PerformanceObligation.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlList;
+import javax.xml.bind.annotation.XmlRootElement;
+import org.joda.time.DateTime;
+import java.util.List;
+
+@XmlRootElement(name = "performance_obligation")
+public class PerformanceObligation extends RecurlyObject {
+
+    @XmlElement(name = "id")
+    private String id;
+
+    @XmlElement(name = "name")
+    private String name;
+
+    @XmlElement(name = "created_at")
+    private DateTime createdAt;
+
+    @XmlElement(name = "updated_at")
+    private DateTime updatedAt;
+
+
+    public String getId() {
+      return this.id;
+    }
+
+    public void setId(final Object id) {
+      this.id = stringOrNull(id);
+    }
+
+    public String getName() {
+      return this.name;
+    }
+
+    public void setName(final Object name) {
+      this.name = stringOrNull(name);
+    }
+
+    public DateTime getCreatedAt() {
+      return this.createdAt;
+    }
+
+    public void setCreatedAt(final Object createdAt) {
+      this.createdAt = dateTimeOrNull(createdAt);
+    }
+
+    public DateTime getUpdatedAt() {
+      return updatedAt;
+    }
+
+    public void setUpdatedAt(final Object updatedAt) {
+      this.updatedAt = dateTimeOrNull(updatedAt);
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder("PerformanceObligation{");
+      sb.append("id='").append(id).append('\'');
+      sb.append(", name='").append(name).append('\'');
+      sb.append(", createdAt='").append(createdAt).append('\'');
+      sb.append(", updatedAt='").append(updatedAt).append('\'');
+      sb.append('}');
+      return sb.toString();
+    }
+}

--- a/src/main/java/com/ning/billing/recurly/model/PerformanceObligations.java
+++ b/src/main/java/com/ning/billing/recurly/model/PerformanceObligations.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+@XmlRootElement(name = "performance_obligations")
+public class PerformanceObligations extends RecurlyObjects<PerformanceObligation> {
+
+    @XmlTransient
+    public static final String PERFORMANCE_OBLIGATIONS_RESOURCE = "/performance_obligations";
+
+    @XmlTransient
+    private static final String PROPERTY_NAME = "performance_obligation";
+
+    @JsonSetter(value = PROPERTY_NAME)
+    @Override
+    public void setRecurlyObject(final PerformanceObligation value) {
+        super.setRecurlyObject(value);
+    }
+
+    @JsonIgnore
+    @Override
+    public PerformanceObligations getStart() {
+        return getStart(PerformanceObligations.class);
+    }
+
+    @JsonIgnore
+    @Override
+    public PerformanceObligations getNext() {
+        return getNext(PerformanceObligations.class);
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestPerformanceObligation.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPerformanceObligation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+ package com.ning.billing.recurly.model;
+
+ import java.util.List;
+
+ import org.joda.time.DateTime;
+ import org.testng.Assert;
+ import static org.testng.Assert.assertTrue;
+ import org.testng.annotations.Test;
+
+ public class TestPerformanceObligation extends TestModelBase {
+
+     @Test(groups = "fast")
+     public void testDeserialization() throws Exception {
+        final String performanceObligationData =
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+           "<performance_obligation href=\"https://your-subdomain.recurly.com/v2/performance_obligation/scaig66ovogw\">" +
+           "  <id>scaig66ovogw</id>" +
+           "  <name>pob-1</name>" +
+           "  <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
+           "  <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
+           "</performance_obligation>";
+
+        final PerformanceObligation performanceObligation = xmlMapper.readValue(performanceObligationData, PerformanceObligation.class);
+
+        Assert.assertEquals(performanceObligation.getHref(), "https://your-subdomain.recurly.com/v2/performance_obligation/scaig66ovogw");
+        Assert.assertEquals(performanceObligation.getId(), "scaig66ovogw");
+        Assert.assertEquals(performanceObligation.getName(), "pob-1");
+        Assert.assertEquals(performanceObligation.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+        Assert.assertEquals(performanceObligation.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+     }
+ }

--- a/src/test/java/com/ning/billing/recurly/model/TestPerformanceObligations.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPerformanceObligations.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+ package com.ning.billing.recurly.model;
+
+ import java.util.List;
+
+ import org.joda.time.DateTime;
+ import org.testng.Assert;
+ import org.testng.annotations.Test;
+
+ public class TestPerformanceObligations extends TestModelBase {
+
+     @Test(groups = "fast")
+     public void testDeserialization() throws Exception {
+        final String perfromanceObligationsData =
+           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+           "<performance_obligations type=\"array\">" +
+           "  <performance_obligation href=\"https://your-subdomain.recurly.com/v2/performance_obligation/scaig66ovogw\">" +
+           "    <id>scaig66ovogw</id>" +
+           "    <name>poab-1</name>" +
+           "    <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
+           "    <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
+           "  </performance_obligation>" +
+           "</performance_obligations>";
+
+        final PerformanceObligations performanceObligations = xmlMapper.readValue(perfromanceObligationsData, PerformanceObligations.class);
+        Assert.assertEquals(performanceObligations.size(), 1);
+
+        final PerformanceObligation performanceObligation = performanceObligations.get(0);
+
+        Assert.assertEquals(performanceObligation.getHref(), "https://your-subdomain.recurly.com/v2/performance_obligation/scaig66ovogw");
+        Assert.assertEquals(performanceObligation.getId(), "scaig66ovogw");
+        Assert.assertEquals(performanceObligation.getName(), "poab-1");
+        Assert.assertEquals(performanceObligation.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+        Assert.assertEquals(performanceObligation.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
+     }
+ }


### PR DESCRIPTION
Adds support for GET/LIST of performance obligations to the V2 Java client.

```
// Open Recurly Client
client.open();

// getting:
client.getPerformanceObligation(pobUUID);

// listing:
client.getPerformanceObligations();
```