### PR TITLE
Adding GLAs to BE endpoints

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/BusinessEntity.java
+++ b/src/main/java/com/ning/billing/recurly/model/BusinessEntity.java
@@ -52,6 +52,12 @@ public class BusinessEntity extends RecurlyObject {
     @XmlElement(name = "default_registration_number")
     private String defaultRegistrationNumber;
 
+    @XmlElement(name = "default_liability_gl_account_id")
+    private String defaultLiabilityGlAccountId;
+
+    @XmlElement(name = "default_revenue_gl_account_id")
+    private String defaultRevenueGlAccountId;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -116,7 +122,23 @@ public class BusinessEntity extends RecurlyObject {
     public String getDefaultRegistrationNumber() {
       return this.defaultRegistrationNumber;
     }
-    
+
+    public void setDefaultLiabilityGlAccountId(final Object defaultLiabilityGlAccountId) {
+      this.defaultLiabilityGlAccountId = stringOrNull(defaultLiabilityGlAccountId);
+    }
+
+    public String getDefaultLiabilityGlAccountId() {
+      return this.defaultLiabilityGlAccountId;
+    }
+
+    public void setDefaultRevenueGlAccountId(final Object defaultRevenueGlAccountId) {
+      this.defaultRevenueGlAccountId = stringOrNull(defaultRevenueGlAccountId);
+    }
+
+    public String getDefaultRevenueGlAccountId() {
+      return this.defaultRevenueGlAccountId;
+    }
+
     public DateTime getCreatedAt() {
       return this.createdAt;
     }
@@ -161,6 +183,8 @@ public class BusinessEntity extends RecurlyObject {
       ", subscriberLocationCountries='" + getSubscriberLocationCountries() + "'" +
       ", defaultVatNumber='" + getDefaultVatNumber() + "'" +
       ", defaultRegistrationNumber='" + getDefaultRegistrationNumber() + "'" +
+      ", defaultLiabilityGlAccountId='" + getDefaultLiabilityGlAccountId() + "'" +
+      ", defaultRevenueGlAccountId='" + getDefaultRevenueGlAccountId() + "'" +
       ", createdAt='" + getCreatedAt() + "'" +
       ", updatedAt='" + getUpdatedAt() + "'" +
       ", invoices='" + getInvoices().getHref() + "'" +

--- a/src/test/java/com/ning/billing/recurly/model/TestBusinessEntities.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBusinessEntities.java
@@ -22,12 +22,12 @@
  import org.joda.time.DateTime;
  import org.testng.Assert;
  import org.testng.annotations.Test;
- 
+
  public class TestBusinessEntities extends TestModelBase {
- 
+
      @Test(groups = "fast")
      public void testDeserialization() throws Exception {
-        final String businessEntitiesData = 
+        final String businessEntitiesData =
            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
            "<business_entities type=\"array\">" +
            "  <business_entity href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw\">" +
@@ -59,14 +59,16 @@
            "    </subscriber_location_countries>" +
            "    <default_vat_number>1234</default_vat_number>" +
            "    <default_registration_number>5678</default_registration_number>" +
+           "    <default_liability_gl_account_id>sriq9hcg4jww</default_liability_gl_account_id>" +
+           "    <default_revenue_gl_account_id>sriq9hdomqm2</default_revenue_gl_account_id>" +
            "    <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
            "    <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
            "  </business_entity>" +
            "</business_entities>";
- 
+
         final BusinessEntities businessEntities = xmlMapper.readValue(businessEntitiesData, BusinessEntities.class);
         Assert.assertEquals(businessEntities.size(), 1);
- 
+
         final BusinessEntity businessEntity = businessEntities.get(0);
         final List<String> subscriberLocationCountries = businessEntity.getSubscriberLocationCountries();
 
@@ -93,8 +95,9 @@
         Assert.assertEquals(subscriberLocationCountries.get(1), "CO");
         Assert.assertEquals(businessEntity.getDefaultVatNumber(), "1234");
         Assert.assertEquals(businessEntity.getDefaultRegistrationNumber(), "5678");
+        Assert.assertEquals(businessEntity.getDefaultLiabilityGlAccountId(), "sriq9hcg4jww");
+        Assert.assertEquals(businessEntity.getDefaultRevenueGlAccountId(), "sriq9hdomqm2");
         Assert.assertEquals(businessEntity.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
         Assert.assertEquals(businessEntity.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
      }
  }
- 

--- a/src/test/java/com/ning/billing/recurly/model/TestBusinessEntity.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBusinessEntity.java
@@ -22,12 +22,12 @@
  import org.joda.time.DateTime;
  import org.testng.Assert;
  import org.testng.annotations.Test;
- 
+
  public class TestBusinessEntity extends TestModelBase {
- 
+
      @Test(groups = "fast")
      public void testDeserialization() throws Exception {
-        final String businessEntityData = 
+        final String businessEntityData =
            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
            "<business_entity href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw\">" +
            "  <invoices href=\"https://your-subdomain.recurly.com/v2/business_entities/scaig66ovogw/invoices\"/>" +
@@ -58,10 +58,12 @@
            "  </subscriber_location_countries>" +
            "  <default_vat_number>1234</default_vat_number>" +
            "  <default_registration_number>5678</default_registration_number>" +
+         "    <default_liability_gl_account_id>sriq9hcg4jww</default_liability_gl_account_id>" +
+         "    <default_revenue_gl_account_id>sriq9hdomqm2</default_revenue_gl_account_id>" +
            "  <created_at type=\"datetime\">2023-05-04T17:45:43Z</created_at>" +
            "  <updated_at type=\"datetime\">2023-05-04T17:45:43Z</updated_at>" +
            "</business_entity>";
- 
+
         final BusinessEntity businessEntity = xmlMapper.readValue(businessEntityData, BusinessEntity.class);
         final List<String> subscriberLocationCountries = businessEntity.getSubscriberLocationCountries();
 
@@ -88,8 +90,9 @@
         Assert.assertEquals(subscriberLocationCountries.get(1), "CO");
         Assert.assertEquals(businessEntity.getDefaultVatNumber(), "1234");
         Assert.assertEquals(businessEntity.getDefaultRegistrationNumber(), "5678");
+        Assert.assertEquals(businessEntity.getDefaultLiabilityGlAccountId(), "sriq9hcg4jww");
+        Assert.assertEquals(businessEntity.getDefaultRevenueGlAccountId(), "sriq9hdomqm2");
         Assert.assertEquals(businessEntity.getCreatedAt(), new DateTime("2023-05-04T17:45:43Z"));
         Assert.assertEquals(businessEntity.getUpdatedAt(), new DateTime("2023-05-04T17:45:43Z"));
      }
  }
- 


### PR DESCRIPTION
Adds support for GET/LIST of RevRec settings in Business Entities to the V2 Java client.

```
// Open Recurly Client
client.open();

// getting:
client.getBusinessEntity(businessEntityUUID);

// listing:
client.getBusinessEntities();
```