### PR TITLE
add revrec settings to plans

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -103,6 +103,24 @@ public class Plan extends RecurlyObject {
     @XmlElement(name = "setup_fee_revenue_schedule_type")
     private RevenueScheduleType setupFeeRevenueScheduleType;
 
+    @XmlElement(name = "liability_gl_account_id")
+    private String liabilityGlAccountId;
+
+    @XmlElement(name = "revenue_gl_account_id")
+    private String revenueGlAccountId;
+
+    @XmlElement(name = "performance_obligation_id")
+    private String performanceObligationId;
+
+    @XmlElement(name = "setup_fee_liability_gl_account_id")
+    private String setupFeeLiabilityGlAccountId;
+
+    @XmlElement(name = "setup_fee_revenue_gl_account_id")
+    private String setupFeeRevenueGlAccountId;
+
+    @XmlElement(name = "setup_fee_performance_obligation_id")
+    private String setupFeePerformanceObligationId;
+
     @XmlElement(name = "created_at")
     private DateTime createdAt;
 
@@ -294,6 +312,54 @@ public class Plan extends RecurlyObject {
         this.setupFeeAccountingCode = stringOrNull(setupFeeAccountingCode);
     }
 
+    public String getLiabilityGlAccountId() {
+        return liabilityGlAccountId;
+    }
+
+    public void setLiabilityGlAccountId(final Object liabilityGlAccountId) {
+        this.liabilityGlAccountId = stringOrNull(liabilityGlAccountId);
+    }
+
+    public String getRevenueGlAccountId() {
+        return revenueGlAccountId;
+    }
+
+    public void setRevenueGlAccountId(final Object revenueGlAccountId) {
+        this.revenueGlAccountId = stringOrNull(revenueGlAccountId);
+    }
+
+    public String getPerformanceObligationId() {
+        return performanceObligationId;
+    }
+
+    public void setPerformanceObligationId(final Object performanceObligationId) {
+        this.performanceObligationId = stringOrNull(performanceObligationId);
+    }
+
+    public String getSetupFeeLiabilityGlAccountId() {
+        return setupFeeLiabilityGlAccountId;
+    }
+
+    public void setSetupFeeLiabilityGlAccountId(final Object setupFeeLiabilityGlAccountId) {
+        this.setupFeeLiabilityGlAccountId = stringOrNull(setupFeeLiabilityGlAccountId);
+    }
+
+    public String getSetupFeeRevenueGlAccountId() {
+        return setupFeeRevenueGlAccountId;
+    }
+
+    public void setSetupFeeRevenueGlAccountId(final Object setupFeeRevenueGlAccountId) {
+        this.setupFeeRevenueGlAccountId = stringOrNull(setupFeeRevenueGlAccountId);
+    }
+
+    public String getSetupFeePerformanceObligationId() {
+        return setupFeePerformanceObligationId;
+    }
+
+    public void setSetupFeePerformanceObligationId(final Object setupFeePerformanceObligationId) {
+        this.setupFeePerformanceObligationId = stringOrNull(setupFeePerformanceObligationId);
+    }
+
     public DateTime getCreatedAt() {
         return createdAt;
     }
@@ -434,6 +500,12 @@ public class Plan extends RecurlyObject {
         sb.append(", taxCode=").append(taxCode);
         sb.append(", allowAnyItemOnSubscriptions=").append(allowAnyItemOnSubscriptions);
         sb.append(", customFields=").append(customFields);
+        sb.append(", liabilityGlAccountId=").append(liabilityGlAccountId);
+        sb.append(", revenueGlAccountId=").append(revenueGlAccountId);
+        sb.append(", performanceObligationId=").append(performanceObligationId);
+        sb.append(", setupFeeLiabilityGlAccountId=").append(setupFeeLiabilityGlAccountId);
+        sb.append(", setupFeeRevenueGlAccountId=").append(setupFeeRevenueGlAccountId);
+        sb.append(", setupFeePerformanceObligationId=").append(setupFeePerformanceObligationId);
         sb.append('}');
         return sb.toString();
     }
@@ -542,6 +614,30 @@ public class Plan extends RecurlyObject {
             return false;
         }
 
+        if (liabilityGlAccountId != null ? liabilityGlAccountId.compareTo(plan.liabilityGlAccountId) != 0: plan.liabilityGlAccountId != null) {
+            return false;
+        }
+
+        if (revenueGlAccountId != null ? revenueGlAccountId.compareTo(plan.revenueGlAccountId) != 0: plan.revenueGlAccountId != null) {
+            return false;
+        }
+
+        if (performanceObligationId != null ? performanceObligationId.compareTo(plan.performanceObligationId) != 0: plan.performanceObligationId != null) {
+            return false;
+        }
+
+        if (setupFeeLiabilityGlAccountId != null ? setupFeeLiabilityGlAccountId.compareTo(plan.setupFeeLiabilityGlAccountId) != 0: plan.setupFeeLiabilityGlAccountId != null) {
+            return false;
+        }
+
+        if (setupFeeRevenueGlAccountId != null ? setupFeeRevenueGlAccountId.compareTo(plan.setupFeeRevenueGlAccountId) != 0: plan.setupFeeRevenueGlAccountId != null) {
+            return false;
+        }
+
+        if (setupFeePerformanceObligationId != null ? setupFeePerformanceObligationId.compareTo(plan.setupFeePerformanceObligationId) != 0: plan.setupFeePerformanceObligationId != null) {
+            return false;
+        }
+
         return true;
     }
 
@@ -579,7 +675,13 @@ public class Plan extends RecurlyObject {
                 taxExempt,
                 taxCode,
                 allowAnyItemOnSubscriptions,
-                customFields
+                customFields,
+                liabilityGlAccountId,
+                revenueGlAccountId,
+                performanceObligationId,
+                setupFeeLiabilityGlAccountId,
+                setupFeeRevenueGlAccountId,
+                setupFeePerformanceObligationId
         );
     }
 }

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -119,6 +119,12 @@ public class TestPlan extends TestModelBase {
                                 "  <setup_fee_accounting_code nil=\"nil\"></setup_fee_accounting_code>\n" +
                                 "  <revenue_schedule_type>evenly</revenue_schedule_type>\n" +
                                 "  <setup_fee_revenue_schedule_type>evenly</setup_fee_revenue_schedule_type>>\n" +
+                                "  <liability_gl_account_id>1234abcd</liability_gl_account_id>\n" +
+                                "  <revenue_gl_account_id>5678efgh</revenue_gl_account_id>\n" +
+                                "  <performance_obligation_id>9012ijkl</performance_obligation_id>\n" +
+                                "  <setup_fee_liability_gl_account_id>3456mnop</setup_fee_liability_gl_account_id>\n" +
+                                "  <setup_fee_revenue_gl_account_id>7890qrst</setup_fee_revenue_gl_account_id>\n" +
+                                "  <setup_fee_performance_obligation_id>1234uvwx</setup_fee_performance_obligation_id>\n" +
                                 "  <created_at type=\"dateTime\">2011-04-19T07:00:00Z</created_at>\n" +
                                 "  <updated_at type=\"dateTime\">2011-04-19T07:00:00Z</updated_at>\n" +
                                 "  <tax_exempt>false</tax_exempt>\n" +
@@ -152,6 +158,12 @@ public class TestPlan extends TestModelBase {
         Assert.assertEquals(plan.getSetupFeeRevenueScheduleType(), RevenueScheduleType.EVENLY);
         Assert.assertEquals(plan.getTaxExempt(), new Boolean(false));
         Assert.assertEquals(plan.getTaxCode(), "digital");
+        Assert.assertEquals(plan.getLiabilityGlAccountId(), "1234abcd");
+        Assert.assertEquals(plan.getRevenueGlAccountId(), "5678efgh");
+        Assert.assertEquals(plan.getPerformanceObligationId(), "9012ijkl");
+        Assert.assertEquals(plan.getSetupFeeLiabilityGlAccountId(), "3456mnop");
+        Assert.assertEquals(plan.getSetupFeeRevenueGlAccountId(), "7890qrst");
+        Assert.assertEquals(plan.getSetupFeePerformanceObligationId(), "1234uvwx");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Add the ability to apply and update RevRec settings (`liability_gl_account_id`, `revenue_gl_account_id`, and `performance_obligation_id`) to Plans.