### PR TITLE
add revrec settings to shipping methods

### DIFF
--- a/src/main/java/com/ning/billing/recurly/model/ShippingMethod.java
+++ b/src/main/java/com/ning/billing/recurly/model/ShippingMethod.java
@@ -49,6 +49,15 @@ public class ShippingMethod extends RecurlyObject {
     @XmlElement(name = "updated_at")
     private DateTime updatedAt;
 
+    @XmlElement(name = "liability_gl_account_id")
+    private String liabilityGlAccountId;
+
+    @XmlElement(name = "revenue_gl_account_id")
+    private String revenueGlAccountId;
+
+    @XmlElement(name = "performance_obligation_id")
+    private String performanceObligationId;
+
     public String getCode() {
         return code;
     }
@@ -81,6 +90,30 @@ public class ShippingMethod extends RecurlyObject {
         this.taxCode = stringOrNull(taxCode);
     }
 
+    public String getLiabilityGlAccountId() {
+        return liabilityGlAccountId;
+    }
+
+    public void setLiabilityGlAccountId(final Object liabilityGlAccountId) {
+        this.liabilityGlAccountId = stringOrNull(liabilityGlAccountId);
+    }
+
+    public String getRevenueGlAccountId() {
+        return revenueGlAccountId;
+    }
+
+    public void setRevenueGlAccountId(final Object revenueGlAccountId) {
+        this.revenueGlAccountId = stringOrNull(revenueGlAccountId);
+    }
+
+    public String getPerformanceObligationId() {
+        return performanceObligationId;
+    }
+
+    public void setPerformanceObligationId(final Object performanceObligationId) {
+        this.performanceObligationId = stringOrNull(performanceObligationId);
+    }
+
     public DateTime getCreatedAt() {
         return createdAt;
     }
@@ -105,6 +138,9 @@ public class ShippingMethod extends RecurlyObject {
         sb.append(", name=").append(name);
         sb.append(", accountingCode=").append(accountingCode);
         sb.append(", taxCode=").append(taxCode);
+        sb.append(", liabilityGlAccountId=").append(liabilityGlAccountId);
+        sb.append(", revenueGlAccountId=").append(revenueGlAccountId);
+        sb.append(", performanceObligationId=").append(performanceObligationId);
         sb.append(", createdAt=").append(createdAt);
         sb.append(", updatedAt=").append(updatedAt);
         sb.append('}');
@@ -130,6 +166,15 @@ public class ShippingMethod extends RecurlyObject {
         if (taxCode != null ? !taxCode.equals(that.taxCode) : that.taxCode != null) {
             return false;
         }
+        if (liabilityGlAccountId != null ? !liabilityGlAccountId.equals(that.liabilityGlAccountId) : that.liabilityGlAccountId != null) {
+            return false;
+        }
+        if (revenueGlAccountId != null ? !revenueGlAccountId.equals(that.revenueGlAccountId) : that.revenueGlAccountId != null) {
+            return false;
+        }
+        if (performanceObligationId != null ? !performanceObligationId.equals(that.performanceObligationId) : that.performanceObligationId != null) {
+            return false;
+        }
         if (createdAt != null ? createdAt.compareTo(that.createdAt) != 0 : that.createdAt != null) {
             return false;
         }
@@ -147,6 +192,9 @@ public class ShippingMethod extends RecurlyObject {
             name,
             accountingCode,
             taxCode,
+            liabilityGlAccountId,
+            revenueGlAccountId,
+            performanceObligationId,
             createdAt,
             updatedAt
         );

--- a/src/test/java/com/ning/billing/recurly/model/TestShippingMethod.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestShippingMethod.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import com.ning.billing.recurly.TestUtils;
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestShippingMethod extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String shippingMethodData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<shipping_method href=\"https://api.recurly.com/v2/shipping_methods/tree_fiddy\">\n" +
+                                "  <code>tree_fiddy</code>\n" +
+                                "  <name>Lochness Monster</name>\n" +
+                                "  <accounting_code>8vn3j9</accounting_code>\n" +
+                                "  <tax_code>p3o838oske</tax_code>\n" +
+                                "  <liability_gl_account_id>lk73h77s</liability_gl_account_id>\n" +
+                                "  <revenue_gl_account_id>oiv983l</revenue_gl_account_id>\n" +
+                                "  <performance_obligation_id>vaww4422</performance_obligation_id>\n" +
+                                "  <created_at type=\"datetime\">2019-04-19T07:00:00Z</created_at>\n" +
+                                "  <updated_at type=\"datetime\">2019-04-19T07:00:00Z</updated_at>\n" +
+                                "</shipping_method>";
+
+        final ShippingMethod shippingMethod = xmlMapper.readValue(shippingMethodData, ShippingMethod.class);
+        Assert.assertEquals(shippingMethod.getCode(), "tree_fiddy");
+        Assert.assertEquals(shippingMethod.getName(), "Lochness Monster");
+        Assert.assertEquals(shippingMethod.getAccountingCode(), "8vn3j9");
+        Assert.assertEquals(shippingMethod.getTaxCode(), "p3o838oske");
+        Assert.assertEquals(shippingMethod.getLiabilityGlAccountId(), "lk73h77s");
+        Assert.assertEquals(shippingMethod.getRevenueGlAccountId(), "oiv983l");
+        Assert.assertEquals(shippingMethod.getPerformanceObligationId(), "vaww4422");
+        Assert.assertEquals(shippingMethod.getCreatedAt(), new DateTime("2019-04-19T07:00:00Z"));
+        Assert.assertEquals(shippingMethod.getUpdatedAt(), new DateTime("2019-04-19T07:00:00Z"));
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/model/TestShippingMethods.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestShippingMethods.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestShippingMethods extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String shippingMethodsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                 "<shippind_methods type=\"array\">\n" +
+                                    "<shipping_method href=\"https://api.recurly.com/v2/shipping_methods/tree_fiddy\">\n" +
+                                    "  <code>tree_fiddy</code>\n" +
+                                    "  <name>Lochness Monster</name>\n" +
+                                    "  <accounting_code>8vn3j9</accounting_code>\n" +
+                                    "  <tax_code>p3o838oske</tax_code>\n" +
+                                    "  <liability_gl_account_id>lk73h77s</liability_gl_account_id>\n" +
+                                    "  <revenue_gl_account_id>oiv983l</revenue_gl_account_id>\n" +
+                                    "  <performance_obligation_id>5</performance_obligation_id>\n" +
+                                    "  <created_at type=\"datetime\">2019-04-19T07:00:00Z</created_at>\n" +
+                                    "  <updated_at type=\"datetime\">2019-04-19T07:00:00Z</updated_at>\n" +
+                                    "</shipping_method>" +
+                                    "<shipping_method href=\"https://api.recurly.com/v2/shipping_methods/chevrolet_movie_theater\">\n" +
+                                    "  <code>chevrolet_movie_theater</code>\n" +
+                                    "  <name>Interior</name>\n" +
+                                    "  <accounting_code>crocodile</accounting_code>\n" +
+                                    "  <tax_code>alligator</tax_code>\n" +
+                                    "  <liability_gl_account_id>av3af224</liability_gl_account_id>\n" +
+                                    "  <revenue_gl_account_id>j8sd89aa</revenue_gl_account_id>\n" +
+                                    "  <performance_obligation_id>6</performance_obligation_id>\n" +
+                                    "  <created_at type=\"datetime\">2019-04-19T07:00:00Z</created_at>\n" +
+                                    "  <updated_at type=\"datetime\">2019-04-19T07:00:00Z</updated_at>\n" +
+                                    "</shipping_method>" +
+                                 "</shippind_methods>";
+
+        final ShippingMethods shippingMethods = xmlMapper.readValue(shippingMethodsData, ShippingMethods.class);
+        Assert.assertEquals(shippingMethods.size(), 2);
+
+        final ShippingMethod shippingMethod1 = shippingMethods.get(0);
+        Assert.assertEquals(shippingMethod1.getCode(), "tree_fiddy");
+        Assert.assertEquals(shippingMethod1.getName(), "Lochness Monster");
+        Assert.assertEquals(shippingMethod1.getAccountingCode(), "8vn3j9");
+        Assert.assertEquals(shippingMethod1.getTaxCode(), "p3o838oske");
+        Assert.assertEquals(shippingMethod1.getLiabilityGlAccountId(), "lk73h77s");
+        Assert.assertEquals(shippingMethod1.getRevenueGlAccountId(), "oiv983l");
+        Assert.assertEquals(shippingMethod1.getPerformanceObligationId(), "5");
+        Assert.assertEquals(shippingMethod1.getCreatedAt(), new DateTime("2019-04-19T07:00:00Z"));
+        Assert.assertEquals(shippingMethod1.getUpdatedAt(), new DateTime("2019-04-19T07:00:00Z"));
+
+        final ShippingMethod shippingMethod2 = shippingMethods.get(1);
+        Assert.assertEquals(shippingMethod2.getCode(), "chevrolet_movie_theater");
+        Assert.assertEquals(shippingMethod2.getName(), "Interior");
+        Assert.assertEquals(shippingMethod2.getAccountingCode(), "crocodile");
+        Assert.assertEquals(shippingMethod2.getTaxCode(), "alligator");
+        Assert.assertEquals(shippingMethod2.getLiabilityGlAccountId(), "av3af224");
+        Assert.assertEquals(shippingMethod2.getRevenueGlAccountId(), "j8sd89aa");
+        Assert.assertEquals(shippingMethod2.getPerformanceObligationId(), "6");
+        Assert.assertEquals(shippingMethod2.getCreatedAt(), new DateTime("2019-04-19T07:00:00Z"));
+        Assert.assertEquals(shippingMethod2.getUpdatedAt(), new DateTime("2019-04-19T07:00:00Z"));
+    }
+}


### PR DESCRIPTION
Add RevRec elements (`liability_gl_account_id`, `revenue_gl_account_id`, `performance_obligation_id`) to the ShippingMethods model.